### PR TITLE
Added support to adjust drawn image layers based on content insets

### DIFF
--- a/FRDLivelyButton/FRDLivelyButton.m
+++ b/FRDLivelyButton/FRDLivelyButton.m
@@ -90,7 +90,10 @@ NSString *const kFRDLivelyButtonStyleChangeAnimationDuration = @"kFRDLivelyButto
     [self addTarget:self action:@selector(showUnHighlight) forControlEvents:UIControlEventTouchUpOutside];
     
     // in case the button is not square, the offset will be use to keep our CGPath's centered in it.
-    self.dimension = MIN(CGRectGetWidth(self.frame), CGRectGetHeight(self.frame));
+    double  width   = CGRectGetWidth(self.frame) - (self.contentEdgeInsets.left + self.contentEdgeInsets.right);
+    double  height  = CGRectGetHeight(self.frame) - (self.contentEdgeInsets.top + self.contentEdgeInsets.bottom);
+
+    self.dimension = MIN(width, height);
     self.offset = CGPointMake((CGRectGetWidth(self.frame) - self.dimension) / 2.0f,
                               (CGRectGetHeight(self.frame) - self.dimension) / 2.0f);
     


### PR DESCRIPTION
- Added support to adjust drawn image layers based on content insets, allow hit area to be increased without adjusting size of drawn image layers.

Signed-off-by: Darren Ehlers me@darrenehlers.com
